### PR TITLE
More flexibility

### DIFF
--- a/config.py
+++ b/config.py
@@ -55,6 +55,7 @@ class NetworkParameters:
                             [0.8, 0.6, 1.73, -0.6, 0],
                             [0.8, 0.6, 1.73, -0.6, 1.5708],
                             ], dtype=np.float32).tolist()
+    nb_dims = 3
 
     positive_iou_threshold = 0.6
     negative_iou_threshold = 0.3

--- a/processors.py
+++ b/processors.py
@@ -68,8 +68,11 @@ class DataProcessor(Parameters):
         labels = list(filter(lambda x: x.classification in self.classes, labels))
         
         if len(labels) == 0:
-            return
-        
+            pX, pY = int(self.Xn / self.downscaling_factor), int(self.Yn / self.downscaling_factor)
+            a = int(self.anchor_dims.shape[0])
+            return np.zeros((pX, pY, a), dtype='float32'), np.zeros((pX, pY, a, self.nb_dims), dtype='float32'),\
+                   np.zeros((pX, pY, a, self.nb_dims), dtype='float32'), np.zeros((pX, pY, a), dtype='float32'),\
+                   np.zeros((pX, pY, a, self.nb_classes), dtype='float64')
         
         #For each label file, generate these properties except for the Don't care class
         target_positions = np.array([label.centroid for label in labels], dtype=np.float32)

--- a/src/point_pillars.cpp
+++ b/src/point_pillars.cpp
@@ -438,21 +438,22 @@ pybind11::array_t<float> createPillarsTarget(const pybind11::array_t<float>& obj
     for (const auto& labelBox: labelBoxes) //For every label box which is a 3d bounding box
     {
         // zone-in on potential spatial area of interest
-        // Length of (length,z) axis diagonal. 
-        float objectDiameter = std::sqrt(std::pow(labelBox.height, 2) + std::pow(labelBox.length, 2));
-        // Offset = Number of x axis grid boxes that can fit on the object diameter
-        const auto offset = static_cast<int>(std::ceil(objectDiameter / (xStep * downscalingFactor)));
-        // Xc = Number of x axis grid boxes that can fit between Xmin and Label's x coordinate
+        // Length of (width,length) axis diagonal.
+        float objectDiameter = std::sqrt(std::pow(labelBox.width, 2) + std::pow(labelBox.length, 2));
+        // Offset = Number of grid boxes that can fit on the object diameter
+        const auto x_offset = static_cast<int>(std::ceil(objectDiameter / (xStep * downscalingFactor)));
+        const auto y_offset = static_cast<int>(std::ceil(objectDiameter / (yStep * downscalingFactor)));
+        // Xc = Number of grid boxes that can fit between Xmin (Ymin) and Label's x (y) coordinate
         const auto xC = static_cast<int>(std::floor((labelBox.x - xMin) / (xStep * downscalingFactor)));
-        // XStart = Start from Xc - Number of boxes in object's diameter.
-        // For example the object is located at 5 unites and is 2 unites long. Then Xstart will begin
-        // the search from 3
-        const auto xStart = clip(xC - offset, 0, xSize);
-        // Similarly end the search at 8 units. Because the object cannot extend beyond that.
-        const auto xEnd = clip(xC + offset, 0, xSize);
         const auto yC = static_cast<int>(std::floor((labelBox.y - yMin) / (yStep * downscalingFactor)));
-        const auto yStart = clip(yC - offset, 0, ySize);
-        const auto yEnd = clip(yC + offset, 0, ySize);
+        // X(Y)Start = Start from Xc (Yc) - Number of boxes in object's diameter.
+        // For example the object is located at 5 unites and is 2 unites long. Then X(Y)start will begin
+        // the search from 3
+        const auto xStart = clip(xC - x_offset, 0, xSize);
+        const auto yStart = clip(yC - y_offset, 0, ySize);
+        // Similarly end the search at 8 units. Because the object cannot extend beyond that.
+        const auto xEnd = clip(xC + x_offset, 0, xSize);
+        const auto yEnd = clip(yC + y_offset, 0, ySize);
 
         float maxIou = 0;
         BoundingBox3D bestAnchor = {};


### PR DESCRIPTION
1. First commit is required if your training data contains empty samples with no present objects
2. Second commit should be a more general version that allows for non-identical step sizes in x and y. Also, I think labelBox.height and lB.width were mixed up. 